### PR TITLE
Remove left over references to "Bridge Description Language"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # TriggerMesh Integration Language
 
-Specification and interpreter for TriggerMesh's Bridge Description Language.
+Specification and interpreter for TriggerMesh's Integration Language.
 
-The TriggerMesh Integration Language (TIL) is a configuration language based on the [HCL syntax][hcl-spec] which purpose is to
-provide a user-friendly interface for describing [TriggerMesh Bridges][tm-brg].
+The TriggerMesh Integration Language (TIL) is a configuration language based on the [HCL syntax][hcl-spec] which purpose
+is to provide a user-friendly interface for describing [TriggerMesh Bridges][tm-brg].
 
 Using the `til` CLI tool, it is possible to turn Bridge definitions into deployment manifests which can run
 complete messaging systems on the TriggerMesh platform.

--- a/config/file/doc.go
+++ b/config/file/doc.go
@@ -17,6 +17,6 @@ limitations under the License.
 // Package file contains utilities for parsing and decoding Bridge Description Files.
 //
 // It is responsible for configuration parsing and static validation, but not
-// for the runtime aspects of the Bridge Description Language, such as
+// for the runtime aspects of the TriggerMesh Integration Language, such as
 // evaluating expressions, which is the responsibility of the "lang" package.
 package file

--- a/core/eval.go
+++ b/core/eval.go
@@ -32,7 +32,7 @@ import (
 // functions that are required for decoding HCL configurations.
 //
 // Traversal expressions always represent references to Addressable blocks in
-// the current version of the Bridge Description Language. Therefore, all
+// the current version of the TriggerMesh Integration Language. Therefore, all
 // variables values stored in this Evaluator represent event addresses. This
 // may change in the future.
 type Evaluator struct {

--- a/core/transform_connect_refs.go
+++ b/core/transform_connect_refs.go
@@ -45,7 +45,7 @@ type AddressableVertex interface {
 type ReferenceableVertex interface {
 	Referenceable() addr.Referenceable
 
-	// In the current version of the Bridge Description Language, a
+	// In the current version of the TriggerMesh Integration Language, a
 	// Referenceable vertex must also expose an address and accept events.
 	// This may change in the future.
 	AddressableVertex

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
 # Documentation
 
-This directory contains documents that describe various aspects of TriggerMesh's _Bridge Description Language_: its
+This directory contains documents that describe various aspects of the _TriggerMesh Integration Language_: its
 specification, the architecture of the interpreter, etc.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,8 +33,8 @@ to achieve.
 
 Like Terraform, `til`...
 
-* Interprets configuration files written in a language based on the [HCL syntax][hcl-spec] (the [_Bridge Description
-  Language_][bdl-spec]).
+* Interprets configuration files written in a language based on the [HCL syntax][hcl-spec] (the [_TriggerMesh
+  Integration Language_][til-spec]).
 * Supports cross-references between HCL configuration blocks using traversal expressions.
 * Represents configuration blocks and the relationships between them as a directed graph.
 * Uses internal schemas ([`hcldec.Spec`][hcldec-spec]) for decoding the contents of HCL blocks into concrete
@@ -120,7 +120,7 @@ is being walked.
 <!-- internal links -->
 [arch-graph]: .assets/arch-request-flow.svg
 [topo-sort-graph]: .assets/topological-sort.svg
-[bdl-spec]: language-spec.md
+[til-spec]: language-spec.md
 [pkgcore-graphb]: https://github.com/triggermesh/til/blob/bf0d78bd/core/graph.go#L10-L15
 [pkgcore-grapht]: https://github.com/triggermesh/til/blob/bf0d78bd/core/graph.go#L52-L55
 [pkgcore-brgtrsl]: https://github.com/triggermesh/til/blob/bf0d78bd/core/translate.go#L13-L18

--- a/docs/language-spec.md
+++ b/docs/language-spec.md
@@ -1,6 +1,6 @@
-# Bridge Description Language Specification
+# TriggerMesh Integration Language Specification
 
-The Bridge Description Language is a configuration language based on the [HCL syntax][hcl-spec] which purpose is to
+The TriggerMesh Integration Language is a configuration language based on the [HCL syntax][hcl-spec] which purpose is to
 offer a user-friendly interface for describing [TriggerMesh Bridges][tm-brg].
 
 ## Contents

--- a/lang/doc.go
+++ b/lang/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package lang deals with the runtime aspects of the Bridge Description
+// Package lang deals with the runtime aspects of the TriggerMesh Integration
 // Language, such as decoding the remainder of partial contents, or evaluating
 // functions and expressions.
 //

--- a/lang/funcs.go
+++ b/lang/funcs.go
@@ -23,7 +23,7 @@ import (
 	"til/lang/funcs"
 )
 
-// Functions returns all functions supported by the Bridge Description
+// Functions returns all functions supported by the TriggerMesh Integration
 // Language, scoped at basedir for functions that access the file system via
 // the fs interface.
 func Functions(basedir string, fs fs.FS) map[string]function.Function {

--- a/lang/k8s/doc.go
+++ b/lang/k8s/doc.go
@@ -14,6 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package k8s contains elements of the Bridge Description Language which are
-// Kubernetes-specific.
+// Package k8s contains elements of the TriggerMesh Integration Language which
+// are Kubernetes-specific.
 package k8s

--- a/lang/ref.go
+++ b/lang/ref.go
@@ -32,7 +32,7 @@ import (
 // discovering variables in the body.
 //
 // It is assumed that every hcl.Traversal attribute is a block reference in the
-// Bridge Description Language, therefore error diagnostics are returned
+// TriggerMesh Integration Language, therefore error diagnostics are returned
 // whenever a hcl.Traversal which doesn't match this predicate is encountered.
 func BlockReferencesInBody(b hcl.Body, s hcldec.Spec) ([]*addr.Reference, hcl.Diagnostics) {
 	return blockReferences(hcldec.Variables(b, s))


### PR DESCRIPTION
Search/replace a few more references to "Bridge Description Language" within the code.
Replace with "TriggerMesh Integration Language".