### PR TITLE
Deduplicate diagnostics during components translation

### DIFF
--- a/core/diagnostic/diagnostic.go
+++ b/core/diagnostic/diagnostic.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostic
+
+import "github.com/hashicorp/hcl/v2"
+
+// DedupDiagnostics allows the accumulation of hcl.Diagnostic while avoiding
+// duplicate entries. It implements a subset of the methods of hcl.Diagnostics.
+type DedupDiagnostics struct {
+	diags hcl.Diagnostics
+	// An index of the diagnostic entries present in the diags list.
+	index map[diagIndex]struct{}
+}
+
+// diagIndex is a reduced version of a hcl.Diagnostic which uniquely identifies
+// a given instance of a particular diagnostic.
+// It is meant to be used as the key to an index of diagnostics.
+type diagIndex struct {
+	summary string
+	detail  string
+	subject hcl.Range
+}
+
+// indexableDiag takes a hcl.Diagnostic and returns a corresponding diagIndex.
+func indexableDiag(diag *hcl.Diagnostic) diagIndex {
+	dIdx := diagIndex{
+		summary: diag.Summary,
+		detail:  diag.Detail,
+	}
+
+	if subj := diag.Subject; subj != nil {
+		dIdx.subject = *subj
+	}
+
+	return dIdx
+}
+
+// NewDedupDiagnostics returns an initialized DedupDiagnostics.
+func NewDedupDiagnostics() *DedupDiagnostics {
+	return &DedupDiagnostics{
+		index: make(map[diagIndex]struct{}),
+	}
+}
+
+// Append appends a new hcl.Diagnostic to the receiver and returns the whole
+// DedupDiagnostics.
+func (d *DedupDiagnostics) Append(diag *hcl.Diagnostic) *DedupDiagnostics {
+	diagIdx := indexableDiag(diag)
+
+	if _, exists := d.index[diagIdx]; exists {
+		return d
+	}
+
+	d.index[diagIdx] = struct{}{}
+	d.diags = append(d.diags, diag)
+
+	return d
+}
+
+// Extend concatenates the given hcl.Diagnostics with the receiver after
+// filtering the diagnostics that already exist, and returns the whole
+// DedupDiagnostics.
+func (d *DedupDiagnostics) Extend(diags hcl.Diagnostics) *DedupDiagnostics {
+	filteredDiags := diags[:0]
+
+	for _, diag := range diags {
+		diagIdx := indexableDiag(diag)
+
+		if _, exists := d.index[diagIdx]; exists {
+			continue
+		}
+
+		d.index[diagIdx] = struct{}{}
+		filteredDiags = append(filteredDiags, diag)
+	}
+
+	d.diags = append(d.diags, filteredDiags...)
+
+	return d
+}
+
+// Diagnostics returns the hcl.Diagnostics accumulated in the receiver.
+func (d *DedupDiagnostics) Diagnostics() hcl.Diagnostics {
+	return d.diags
+}

--- a/core/diagnostic/diagnostic_test.go
+++ b/core/diagnostic/diagnostic_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package diagnostic_test
+
+import (
+	"strings"
+	"testing"
+
+	. "til/core/diagnostic"
+
+	"github.com/hashicorp/hcl/v2"
+)
+
+func TestDedupDiagnostics(t *testing.T) {
+	diag1 := newDiagnostic("Roof", "The roof is on fire", 10, 15)
+	diag2 := newDiagnostic("House", "The house is on fire", 20, 25)
+	diag3 := newDiagnostic("World", "The world is on fire", 30, 35)
+
+	t.Run("Append non-equal diagnostics", func(t *testing.T) {
+		d := NewDedupDiagnostics()
+
+		d = d.Append(diag1)
+		d = d.Append(diag2)
+		d = d.Append(diag3)
+
+		gotDiags := d.Diagnostics()
+
+		const expectNumDiags = 3
+		if gotNumDiags := len(gotDiags); gotNumDiags != expectNumDiags {
+			t.Fatalf("Expected %d diagnostics, got %d:\n%s",
+				expectNumDiags, gotNumDiags, errDiagsAsString(gotDiags))
+		}
+	})
+
+	t.Run("Append equal diagnostics", func(t *testing.T) {
+		d := NewDedupDiagnostics()
+
+		d = d.Append(diag1)
+		d = d.Append(diag1) // dupe
+		d = d.Append(diag2)
+		d = d.Append(diag1) // dupe
+
+		gotDiags := d.Diagnostics()
+
+		const expectNumDiags = 2
+		if gotNumDiags := len(gotDiags); gotNumDiags != expectNumDiags {
+			t.Fatalf("Expected %d diagnostics, got %d:\n%s",
+				expectNumDiags, gotNumDiags, errDiagsAsString(gotDiags))
+		}
+	})
+
+	t.Run("Extend with non-equal diagnostics", func(t *testing.T) {
+		d := NewDedupDiagnostics()
+
+		var diags hcl.Diagnostics
+		diags = diags.Append(diag1)
+		diags = diags.Append(diag2)
+		diags = diags.Append(diag3)
+
+		d = d.Extend(diags)
+
+		gotDiags := d.Diagnostics()
+
+		const expectNumDiags = 3
+		if gotNumDiags := len(gotDiags); gotNumDiags != expectNumDiags {
+			t.Fatalf("Expected %d diagnostics, got %d:\n%s",
+				expectNumDiags, gotNumDiags, errDiagsAsString(gotDiags))
+		}
+	})
+
+	t.Run("Extend with equal diagnostics", func(t *testing.T) {
+		d := NewDedupDiagnostics()
+
+		var diags hcl.Diagnostics
+		diags = diags.Append(diag1)
+		diags = diags.Append(diag1) // dupe
+		diags = diags.Append(diag2)
+		diags = diags.Append(diag1) // dupe
+
+		d = d.Extend(diags)
+		d = d.Extend(diags) // push the same list a second time
+
+		gotDiags := d.Diagnostics()
+
+		const expectNumDiags = 2
+		if gotNumDiags := len(gotDiags); gotNumDiags != expectNumDiags {
+			t.Fatalf("Expected %d diagnostics, got %d:\n%s",
+				expectNumDiags, gotNumDiags, errDiagsAsString(gotDiags))
+		}
+	})
+}
+
+func newDiagnostic(summary, detail string, start, end int) *hcl.Diagnostic {
+	rng := func(start, end int) hcl.Range {
+		return hcl.Range{
+			Filename: "mybridge.brg.hcl",
+			Start:    hcl.Pos{Line: 0, Column: start, Byte: 0},
+			End:      hcl.Pos{Line: 0, Column: end, Byte: 0},
+		}
+	}
+
+	return &hcl.Diagnostic{
+		Severity: hcl.DiagError,
+		Summary:  summary,
+		Detail:   detail,
+		Subject:  rng(start, end).Ptr(),
+	}
+}
+
+// errDiagsAsString returns a string representation of all given error
+// diagnostics as individual entries separated by a newline character.
+func errDiagsAsString(diags hcl.Diagnostics) string {
+	var dsb strings.Builder
+
+	errDiags := diags.Errs()
+
+	for i, d := range errDiags {
+		dsb.WriteString(d.Error())
+		if i < len(errDiags) {
+			dsb.WriteRune('\n')
+		}
+	}
+
+	return dsb.String()
+}

--- a/core/diagnostic/doc.go
+++ b/core/diagnostic/doc.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package diagnostic facilitates the manipulation of HCL diagnostics.
+package diagnostic

--- a/encoding/serialization_test.go
+++ b/encoding/serialization_test.go
@@ -19,10 +19,12 @@ package encoding_test
 import (
 	"strings"
 	"testing"
-	. "til/encoding"
 
 	"github.com/google/go-cmp/cmp"
+
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "til/encoding"
 )
 
 func TestWriteManifests(t *testing.T) {


### PR DESCRIPTION
Fixes #146

Ensures the same error diagnostic won't be logged more than once even if it's yielded multiple times during the components translation.

---

**Demo**

With the given bridge description:
```hcl
target container "foo" {
  image = bar
}
```

Before this PR, the same error appeared twice (even if not visible via the default printer):
```console
$ til generate foo.brg.hcl
Error running command: foo.brg.hcl:2,11-14: Unknown variable; There is no variable named "bar"., and 1 other diagnostic(s)
```

With this change:
```console
$ til generate foo.brg.hcl
Error running command: foo.brg.hcl:2,11-14: Unknown variable; There is no variable named "bar".
```