### PR TITLE
Move core CLI functionalities to `cli` package

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+// CLI implements a command-line interface with subcommands.
+type CLI struct {
+	// Name of the CLI (the invoked program)
+	name string
+	// Rest of the command line arguments
+	args []string
+
+	// Main usage text, printed when the user asks for help or when an
+	// error occurs
+	usage string
+
+	// Supported subcommands
+	commands map[string]Command
+
+	// UI for reporting messages/errors to the terminal.
+	// Defaulted to stdout/stderr during initialization.
+	ui UI
+}
+
+// New returns a new instance of a CLI.
+func New(osArgs []string, usage usageFn, opts ...Option) *CLI {
+	// passing empty OS arguments here would be inconsiderate from the
+	// caller, so we make the error loud
+	if len(osArgs) == 0 {
+		panic(errors.New("CLI constructor invoked without OS argument. " + //nolint:stylecheck
+			"At least a program name/path is required."))
+	}
+
+	c := &CLI{
+		name:     osArgs[0],
+		args:     osArgs[1:],
+		usage:    usage(osArgs[0]),
+		commands: make(map[string]Command),
+		ui: UI{
+			StdWriter: os.Stdout,
+			ErrWriter: os.Stderr,
+		},
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	return c
+}
+
+// Run executes the command, passing OS arguments provided during the CLI
+// initialization to the subcommand.
+func (c *CLI) Run() error {
+	// initializing a FlagSet here ensures users can display the general
+	// usage using Go's special '-h, --help' flag
+	f := flag.NewFlagSet(c.name, flag.ExitOnError)
+	f.SetOutput(c.ui.ErrWriter)
+	f.Usage = func() {
+		fmt.Fprint(f.Output(), c.usage)
+	}
+	_ = f.Parse(c.args) // ignore err; the FlagSet uses ExitOnError
+
+	if len(c.args) == 0 {
+		return errors.New("no subcommand provided.\n\n" + c.usage)
+	}
+
+	cmd, exists := c.commands[c.args[0]]
+	if !exists {
+		return fmt.Errorf("unknown subcommand %q.\n\n%s", c.args[0], c.usage)
+	}
+
+	ctx := context.Background()
+	ctx = withFlagSet(ctx, initCmdFlagSet(c.name, c.args[0], c.ui.ErrWriter))
+	ctx = withUI(ctx, &c.ui)
+
+	return cmd.Run(ctx, c.args[1:])
+}
+
+// usageFn returns the usage text for a command, based on the given CLI name.
+type usageFn func(cliName string) string
+
+// Option is a functional option for a CLI.
+type Option func(*CLI)
+
+// Subcommand defines a CLI subcommand.
+func Subcommand(name string, cmd Command) Option {
+	return func(c *CLI) {
+		if _, exists := c.commands[name]; exists {
+			// this would indicate a programmer mistake, so we make
+			// the error loud
+			panic(fmt.Errorf("command %q is defined more than once", name))
+		}
+
+		c.commands[name] = cmd
+	}
+}
+
+// StdWriter sets the writer to which regular messages are written.
+func StdWriter(w io.Writer) Option {
+	return func(c *CLI) {
+		c.ui.StdWriter = w
+	}
+}
+
+// ErrWriter sets the writer to which error messages are written.
+func ErrWriter(w io.Writer) Option {
+	return func(c *CLI) {
+		c.ui.ErrWriter = w
+	}
+}
+
+// UI wraps io.Writer interfaces used by commands to report messages/errors to
+// the terminal.
+type UI struct {
+	StdWriter io.Writer
+	ErrWriter io.Writer
+}
+
+// Command can execute a CLI subcommand.
+//
+// The given context.Context is infused with data and abstractions a subcommand
+// typically needs from the main CLI:
+//  - an initialized flag.FlagSet, which can be augmented with vars and usage text
+//  - a UI instance, for writing messages and errors to the caller's terminal
+type Command interface {
+	Run(ctx context.Context, args []string) error
+}
+
+// initCmdFlagSet returns a flag.FlagSet initialized with a standard name,
+// error handling property and output for a CLI subcommand.
+func initCmdFlagSet(cliName, cmd string, output io.Writer) *flag.FlagSet {
+	flagSet := flag.NewFlagSet(cliName+" "+cmd, flag.ExitOnError)
+	flagSet.SetOutput(output)
+	return flagSet
+}

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"til/cli"
+)
+
+// cmdName is the name of the program passed in all faked OS arguments in this
+// test suite.
+const cmdName = "clitest"
+
+func TestCLI(t *testing.T) {
+	t.Run("run existing subcommand", func(t *testing.T) {
+		var stdout strings.Builder
+		var stderr strings.Builder
+
+		c := cli.New([]string{cmdName, "mycommand", "-A", "-B"}, usageFn,
+			cli.StdWriter(&stdout),
+			cli.ErrWriter(&stderr),
+			cli.Subcommand("mycommand", new(writeAndSucceedCmd)),
+		)
+
+		// The command should run to completion and write its output
+		// to the standard CLI writer.
+		// Flags are ignored due to the absence of flag parsing in our
+		// test's subcommand.
+		err := c.Run()
+
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+		if stderr.String() != "" {
+			t.Errorf("Expected no write to error writer. Got:\n%s", &stderr)
+		}
+
+		if stdout.String() != stdCmdMsg {
+			t.Errorf("Unexpected command output:\n%s", &stdout)
+		}
+	})
+
+	t.Run("global help requested", func(t *testing.T) {
+		var stdout strings.Builder
+		var stderr strings.Builder
+
+		c := cli.New([]string{cmdName, "-help"}, usageFn,
+			cli.StdWriter(&stdout),
+			cli.ErrWriter(&stderr),
+		)
+
+		var err error
+
+		func() {
+			defer func() {
+				// tests need to recover from os.Exit()
+				if r := recover(); r != nil {
+					t.Log("Recovered:", r)
+				} else {
+					t.Fatal("Expected program to exit")
+				}
+			}()
+
+			// the command should exit (code 0) because the special
+			// flag '-h, --help' is encountered
+			err = c.Run()
+		}()
+
+		if err != nil {
+			t.Fatal("Unexpected error:", err)
+		}
+		if stdout.String() != "" {
+			t.Errorf("Expected no write to standard writer. Got:\n%s", &stdout)
+		}
+
+		if stderr.String() != expectedUsageTxt {
+			t.Errorf("Expected only usage text to be written to error writer. Got:\n%s", &stderr)
+		}
+	})
+
+	t.Run("no subcommand given", func(t *testing.T) {
+		var stdout strings.Builder
+		var stderr strings.Builder
+
+		c := cli.New([]string{cmdName}, usageFn,
+			cli.StdWriter(&stdout),
+			cli.ErrWriter(&stderr),
+		)
+
+		err := c.Run()
+
+		if err == nil {
+			t.Fatal("Expected an error to occur")
+		}
+
+		assertNoWrite(t, &stdout, &stderr)
+		assertContainsUsage(t, err.Error())
+
+		if !strings.Contains(err.Error(), "no subcommand provided") {
+			t.Errorf("Unexpected error message: %q", err)
+		}
+	})
+
+	t.Run("subcommand given but not defined", func(t *testing.T) {
+		var stdout strings.Builder
+		var stderr strings.Builder
+
+		c := cli.New([]string{cmdName, "mycommand", "-A", "-B"}, usageFn,
+			cli.StdWriter(&stdout),
+			cli.ErrWriter(&stderr),
+		)
+
+		err := c.Run()
+
+		if err == nil {
+			t.Fatal("Expected an error to occur")
+		}
+
+		assertNoWrite(t, &stdout, &stderr)
+		assertContainsUsage(t, err.Error())
+
+		if !strings.Contains(err.Error(), `unknown subcommand "mycommand"`) {
+			t.Errorf("Unexpected error message: %q", err)
+		}
+	})
+}
+
+// assertNoWrite checks that no write occurred to the CLI writers (stdout/err).
+func assertNoWrite(t *testing.T, stdout, stderr fmt.Stringer) {
+	t.Helper()
+
+	if stdout.String() != "" {
+		t.Errorf("Expected no write to standard writer. Got:\n%s", stdout)
+	}
+	if stderr.String() != "" {
+		t.Errorf("Expected no write to error writer. Got:\n%s", stderr)
+	}
+}
+
+// assertContainsUsage checks that the given message contains the sample usage text.
+func assertContainsUsage(t *testing.T, msg string) {
+	t.Helper()
+
+	if !strings.Contains(msg, expectedUsageTxt) {
+		t.Errorf("Expected given message to contain command usage:\n%s", msg)
+	}
+}
+
+// usageFn returns a short sample usage text for use in tests.
+func usageFn(cliName string) string {
+	return `usage for ` + cliName + ` a.k.a. "HELP!"`
+}
+
+const expectedUsageTxt = `usage for ` + cmdName + ` a.k.a. "HELP!"`
+
+// writeAndSucceedCmd is a minimal implementation of cli.Command for tests,
+// which write a succinct message to the standard writer and returns no error.
+type writeAndSucceedCmd struct{}
+
+var _ cli.Command = (*writeAndSucceedCmd)(nil)
+
+// stdCmdMsg is the message written to test CLIs' standard writer.
+const stdCmdMsg = "Hello, World!"
+
+func (*writeAndSucceedCmd) Run(ctx context.Context, _ []string) error {
+	ui := cli.UIFromContext(ctx)
+	_, _ = ui.StdWriter.Write([]byte(stdCmdMsg))
+	return nil
+}

--- a/cli/context.go
+++ b/cli/context.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2021 TriggerMesh Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"context"
+	"errors"
+	"flag"
+)
+
+// flagSetKey is the Context key for a flag.FlagSet.
+type flagSetKey struct{}
+
+// withFlagSet infuses ctx with the given flag.Flagset.
+func withFlagSet(ctx context.Context, f *flag.FlagSet) context.Context {
+	return context.WithValue(ctx, flagSetKey{}, f)
+}
+
+// FlagSetFromContext retrieves the flag.FlagSet injected into the given context.Context.
+func FlagSetFromContext(ctx context.Context) *flag.FlagSet {
+	f, ok := ctx.Value(flagSetKey{}).(*flag.FlagSet)
+	if !ok {
+		panic(errors.New("flag.FlagSet not found in context"))
+	}
+
+	return f
+}
+
+// uiKey is the Context key for a UI.
+type uiKey struct{}
+
+// withUI infuses ctx with the given UI.
+func withUI(ctx context.Context, ui *UI) context.Context {
+	return context.WithValue(ctx, uiKey{}, ui)
+}
+
+// UIFromContext retrieves the UI injected into the given context.Context.
+func UIFromContext(ctx context.Context) *UI {
+	ui, ok := ctx.Value(uiKey{}).(*UI)
+	if !ok {
+		panic(errors.New("UI not found in context"))
+	}
+
+	return ui
+}

--- a/cli/doc.go
+++ b/cli/doc.go
@@ -14,33 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package main
-
-import (
-	"fmt"
-	"io"
-	"os"
-
-	"til/cli"
-)
-
-func main() {
-	if err := run(os.Args, os.Stdout, os.Stderr); err != nil {
-		fmt.Fprintf(os.Stderr, "Error running command: %s\n", err)
-		os.Exit(1)
-	}
-}
-
-// run executes the command.
-func run(args []string, stdout, stderr io.Writer) error {
-	c := cli.New(args, usage,
-		cli.StdWriter(stdout),
-		cli.ErrWriter(stderr),
-
-		cli.Subcommand(cmdGenerate, new(GenerateCommand)),
-		cli.Subcommand(cmdValidate, new(ValidateCommand)),
-		cli.Subcommand(cmdGraph, new(GraphCommand)),
-	)
-
-	return c.Run()
-}
+// Package cli backs the implementation of CLI commands.
+package cli


### PR DESCRIPTION
Moves core CLI functionalities - such as the action of reading OS args and executing a subcommand - out of `main`, to their own `cli` package.

Adds unit tests for those core CLI functionalities (coverage: 82.9% of statements).